### PR TITLE
More load tests for user search/retrieval

### DIFF
--- a/src/main/java/io/fusionauth/load/BaseWorker.java
+++ b/src/main/java/io/fusionauth/load/BaseWorker.java
@@ -28,9 +28,9 @@ import com.inversoft.rest.ClientResponse;
 public abstract class BaseWorker implements Worker {
   public final static String Password = "11e7ea7b-784d-4687-bf2d-4f8ee479a4dd11e7ea7b-784d-4687-bf2d-4f8ee479a4dd";
 
-  protected static final String ALPHA_CHARACTERS = "BCDFGHJKLMNPQRSTVWXYZ";
+  protected static final String ALPHA_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-  protected static final String ALPHA_NUMERIC_CHARACTERS = "23456789" + ALPHA_CHARACTERS;
+  protected static final String ALPHA_NUMERIC_CHARACTERS = "0123456789" + ALPHA_CHARACTERS;
 
   final Configuration configuration;
 

--- a/src/main/java/io/fusionauth/load/BaseWorker.java
+++ b/src/main/java/io/fusionauth/load/BaseWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2023, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package io.fusionauth.load;
 
+import java.security.SecureRandom;
+
 import com.inversoft.error.Errors;
-import io.fusionauth.load.Configuration;
-import io.fusionauth.load.Worker;
 import com.inversoft.rest.ClientResponse;
 
 /**
@@ -28,6 +28,10 @@ import com.inversoft.rest.ClientResponse;
 public abstract class BaseWorker implements Worker {
   public final static String Password = "11e7ea7b-784d-4687-bf2d-4f8ee479a4dd11e7ea7b-784d-4687-bf2d-4f8ee479a4dd";
 
+  protected static final String ALPHA_CHARACTERS = "BCDFGHJKLMNPQRSTVWXYZ";
+
+  protected static final String ALPHA_NUMERIC_CHARACTERS = "23456789" + ALPHA_CHARACTERS;
+
   final Configuration configuration;
 
   private final boolean debug;
@@ -35,6 +39,16 @@ public abstract class BaseWorker implements Worker {
   protected BaseWorker(Configuration configuration) {
     this.debug = configuration.getBoolean("debug", false);
     this.configuration = configuration;
+  }
+
+  protected static String secureString(int length, String sourceCharacterSet) {
+    SecureRandom random = new SecureRandom();
+    StringBuilder sb = new StringBuilder();
+    while (sb.length() < length) {
+      sb.append(sourceCharacterSet.charAt(random.nextInt(sourceCharacterSet.length())));
+    }
+
+    return sb.substring(0, length);
   }
 
   void printErrors(ClientResponse<?, Errors> result) {

--- a/src/main/java/io/fusionauth/load/FusionAuthRegistrationWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthRegistrationWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2023, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ import io.fusionauth.domain.api.user.RegistrationRequest;
 import io.fusionauth.domain.api.user.RegistrationResponse;
 
 /**
+ * Worker to test creating users and registrations. The user data includes a randomly generated external Id.
+ *
  * @author Daniel DeGroff
  */
 public class FusionAuthRegistrationWorker extends BaseWorker {
@@ -56,6 +58,7 @@ public class FusionAuthRegistrationWorker extends BaseWorker {
     user.password = Password;
     user.encryptionScheme = encryptionScheme;
     user.factor = factor;
+    user.data.put("externalId", secureString(20, ALPHA_NUMERIC_CHARACTERS));
 
     UserRegistration userRegistration = new UserRegistration().with(r -> r.applicationId = applicationId)
                                                               .with(r -> r.roles.add("user"));

--- a/src/main/java/io/fusionauth/load/FusionAuthRetrieveEmailWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthRetrieveEmailWorker.java
@@ -20,31 +20,23 @@ import java.util.Random;
 import com.inversoft.error.Errors;
 import com.inversoft.rest.ClientResponse;
 import io.fusionauth.client.FusionAuthClient;
-import io.fusionauth.domain.api.user.SearchRequest;
-import io.fusionauth.domain.api.user.SearchResponse;
-import io.fusionauth.domain.search.UserSearchCriteria;
+import io.fusionauth.domain.api.UserResponse;
 
 /**
- * Worker to test searching for users by email address.
+ * Worker to test retrieving user by email address.
  *
- * @author Daniel DeGroff
+ * @author Spencer Witt
  */
-public class FusionAuthSearchWorker extends BaseWorker {
+public class FusionAuthRetrieveEmailWorker extends BaseWorker {
   private final FusionAuthClient client;
 
   private final int loginLowerBound;
 
   private final int loginUpperBound;
 
-  private final int numberOfResults;
-
-  private final String queryString;
-
-  public FusionAuthSearchWorker(FusionAuthClient client, Configuration configuration) {
+  public FusionAuthRetrieveEmailWorker(FusionAuthClient client, Configuration configuration) {
     super(configuration);
     this.client = client;
-    this.numberOfResults = configuration.getInteger("numberOfResults");
-    this.queryString = configuration.getString("queryString");
     this.loginLowerBound = configuration.getInteger("loginLowerBound", 0);
     this.loginUpperBound = configuration.getInteger("loginUpperBound", 1_000_000);
   }
@@ -54,10 +46,7 @@ public class FusionAuthSearchWorker extends BaseWorker {
     int random = new Random().nextInt((loginUpperBound - loginLowerBound) + 1) + loginLowerBound;
     String email = "load_user_" + random + "@fusionauth.io";
 
-    String query = queryString.replace("${email}", email);
-    ClientResponse<SearchResponse, Errors> result = client.searchUsersByQuery(new SearchRequest(new UserSearchCriteria()
-                                                                                                    .with(c -> c.numberOfResults = numberOfResults)
-                                                                                                    .with(c -> c.queryString = query)));
+    ClientResponse<UserResponse, Errors> result = client.retrieveUserByEmail(email);
     if (result.wasSuccessful()) {
       return true;
     }

--- a/src/main/java/io/fusionauth/load/FusionAuthSearchWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthSearchWorker.java
@@ -25,7 +25,7 @@ import io.fusionauth.domain.api.user.SearchResponse;
 import io.fusionauth.domain.search.UserSearchCriteria;
 
 /**
- * Worker to test searching for users by email address.
+ * Worker to test search.
  *
  * @author Daniel DeGroff
  */

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -65,6 +65,8 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
       case "oauth2/authorize" -> new FusionAuthOAuth2AuthorizeWorker(client, configuration);
       case "register" -> new FusionAuthRegistrationWorker(client, configuration, counter);
       case "search" -> new FusionAuthSearchWorker(client, configuration);
+      case "search-data" -> new FusionAuthSearchDataWorker(client, configuration);
+      case "retrieve-email" -> new FusionAuthRetrieveEmailWorker(client, configuration);
       case "elasticsearch" -> new ElasticsearchWorker(configuration);
       default -> throw new IllegalArgumentException("Invalid directive [" + directive + "]");
     };

--- a/src/main/resources/User-RetrieveEmail.json
+++ b/src/main/resources/User-RetrieveEmail.json
@@ -1,0 +1,26 @@
+{
+  "loopCount": 2000,
+  "workerCount": 25,
+  "workerFactory": {
+    "className": "io.fusionauth.load.FusionAuthWorkerFactory",
+    "attributes": {
+      "directive": "retrieve-email",
+      "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
+      "url": "https://local.fusionauth.io",
+      "loginLowerBound": 1,
+      "loginUpperBound": 80000,
+      "debug": false
+    }
+  },
+  "listeners": [
+    {
+      "className": "io.fusionauth.load.listeners.ThroughputListener"
+    }
+  ],
+  "reporter": {
+    "className": "io.fusionauth.load.reporters.DefaultReporter",
+    "attributes": {
+      "interval": 5
+    }
+  }
+}

--- a/src/main/resources/User-SearchData.json
+++ b/src/main/resources/User-SearchData.json
@@ -1,0 +1,29 @@
+{
+  "loopCount": 2000,
+  "workerCount": 25,
+  "workerFactory": {
+    "className": "io.fusionauth.load.FusionAuthWorkerFactory",
+    "attributes": {
+      "directive": "search-data",
+      "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
+      "url": "https://local.fusionauth.io",
+      "numberOfResults": 1,
+      "queryString": "${externalId}",
+      "query": "{\n  \"match\": {\n    \"data.externalId\": {\n      \"query\": \"${externalId}\"\n    }\n  }\n}\n",
+      "loginLowerBound": 1,
+      "loginUpperBound": 2500,
+      "debug": false
+    }
+  },
+  "listeners": [
+    {
+      "className": "io.fusionauth.load.listeners.ThroughputListener"
+    }
+  ],
+  "reporter": {
+    "className": "io.fusionauth.load.reporters.DefaultReporter",
+    "attributes": {
+      "interval": 5
+    }
+  }
+}


### PR DESCRIPTION
Add/update load tests for:
1. Add a random `externalId` to user data during the registration load test
2. Add a load test to retrieve users by email address
3. Add a load test to search for users via an `externalId` value on user data