### PR TITLE
Use Java21

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -93,8 +93,8 @@ idea.settings.moduleMap = [
     "io.fusionauth:fusionauth-java-client:${fusionauthVersion}": "fusionauth-java-client",
 ]
 
-java.settings.javaVersion = "17"
-javaTestNG.settings.javaVersion = "17"
+java.settings.javaVersion = "21"
+javaTestNG.settings.javaVersion = "21"
 
 target(name: "clean", description: "Cleans the build directory") {
   java.clean()

--- a/fusionauth-load-tests.iml
+++ b/fusionauth-load-tests.iml
@@ -12,7 +12,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
     </content>
-    <orderEntry type="jdk" jdkName="Java 17" jdkType="JavaSDK" />
+    <orderEntry type="jdk" jdkName="Java 21" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module-library">
       <library>


### PR DESCRIPTION
IJ was failing to build this project because the module settings say "Use Project Default" which is 21, but the JDK selected as a dep was set to `21`. So you'd get an error about the source target being incorrect. 

![image](https://github.com/user-attachments/assets/c637ec7b-4354-47b8-9880-e6d6e67567b9)
