### PR TITLE
Use a virtual thread factory

### DIFF
--- a/src/main/java/io/fusionauth/load/Foreman.java
+++ b/src/main/java/io/fusionauth/load/Foreman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,55 +47,53 @@ public class Foreman implements Buildable<Foreman> {
 
   public Foreman execute() throws InterruptedException {
     initialize();
-    ExecutorService pool = Executors.newFixedThreadPool(workers.size());
+    // Note that we are going to use virtual threads, so in theory we don't need a pool, but we are trying to simulate clients or workers
+    // so keep the thread pool and just use a virtual factory.
+    try (ExecutorService pool = Executors.newFixedThreadPool(workers.size())) {
 
-    // Gradually build up workers, to reduce the chance of failures while we get going.
-    for (Worker worker : workers) {
-      WorkerExecutor executor = new WorkerExecutor(worker, loopCount, listeners);
-      pool.execute(executor);
-      try {
-        Thread.sleep(1123);
-      } catch (Exception ignore) {
+      // Gradually build up workers, to reduce the chance of failures while we get going.
+      for (Worker worker : workers) {
+        WorkerExecutor executor = new WorkerExecutor(worker, loopCount, listeners);
+        pool.execute(executor);
       }
+
+      if (this.reporter != null) {
+        this.reporter.schedule();
+      }
+
+      pool.shutdown();
+      pool.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+
+      listeners.forEach(SampleListener::done);
+
+      if (reporter != null) {
+        reporter.report();
+      }
+
+      if (reporter != null) {
+        reporter.stop();
+      }
+
+      // Temp hack to get some general timings on the OAuth2 Authorize worker broken down by component
+      if (workers.get(0) instanceof FusionAuthOAuth2AuthorizeWorker) {
+        System.out.println("\n\n");
+        long total = FusionAuthOAuth2AuthorizeWorker.timing.render + FusionAuthOAuth2AuthorizeWorker.timing.post + FusionAuthOAuth2AuthorizeWorker.timing.token;
+        long iterationCount = (long) workers.size() * loopCount;
+
+        int renderPercent = (int) (FusionAuthOAuth2AuthorizeWorker.timing.render * 100.0 / total + 0.5);
+        int postPercent = (int) (FusionAuthOAuth2AuthorizeWorker.timing.post * 100.0 / total + 0.5);
+        int tokenPercent = (int) (FusionAuthOAuth2AuthorizeWorker.timing.token * 100.0 / total + 0.5);
+
+        System.out.println("Render: " + FusionAuthOAuth2AuthorizeWorker.timing.render + " ms, Average: " + FusionAuthOAuth2AuthorizeWorker.timing.render / (iterationCount) + " ms, " + (renderPercent) + "%");
+        System.out.println("Post: " + FusionAuthOAuth2AuthorizeWorker.timing.post + " ms, Average: " + FusionAuthOAuth2AuthorizeWorker.timing.post / (iterationCount) + " ms, " + (postPercent) + "%");
+        System.out.println("Token: " + FusionAuthOAuth2AuthorizeWorker.timing.token + " ms, Average: " + FusionAuthOAuth2AuthorizeWorker.timing.token / (iterationCount) + " ms, " + (tokenPercent) + "%");
+        System.out.println("\n\n");
+      }
+
+      done = true;
+      initialized = true;
+      return this;
     }
-
-    if (this.reporter != null) {
-      this.reporter.schedule();
-    }
-
-    pool.shutdown();
-    pool.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-
-    listeners.forEach(SampleListener::done);
-
-    if (reporter != null) {
-      reporter.report();
-    }
-
-    if (reporter != null) {
-      reporter.stop();
-    }
-
-
-    // Temp hack to get some general timings on the OAuth2 Authorize worker broken down by component
-    if (workers.get(0) instanceof FusionAuthOAuth2AuthorizeWorker) {
-      System.out.println("\n\n");
-      long total = FusionAuthOAuth2AuthorizeWorker.timing.render + FusionAuthOAuth2AuthorizeWorker.timing.post + FusionAuthOAuth2AuthorizeWorker.timing.token;
-      long iterationCount = (long) workers.size() * loopCount;
-
-      int renderPercent = (int) (FusionAuthOAuth2AuthorizeWorker.timing.render * 100.0 / total + 0.5);
-      int postPercent = (int) (FusionAuthOAuth2AuthorizeWorker.timing.post * 100.0 / total + 0.5);
-      int tokenPercent = (int) (FusionAuthOAuth2AuthorizeWorker.timing.token * 100.0 / total + 0.5);
-
-      System.out.println("Render: " + FusionAuthOAuth2AuthorizeWorker.timing.render + " ms, Average: " + FusionAuthOAuth2AuthorizeWorker.timing.render / (iterationCount) + " ms, " + (renderPercent) + "%");
-      System.out.println("Post: " + FusionAuthOAuth2AuthorizeWorker.timing.post + " ms, Average: " + FusionAuthOAuth2AuthorizeWorker.timing.post / (iterationCount) + " ms, " + (postPercent) + "%");
-      System.out.println("Token: " + FusionAuthOAuth2AuthorizeWorker.timing.token + " ms, Average: " + FusionAuthOAuth2AuthorizeWorker.timing.token / (iterationCount) + " ms, " + (tokenPercent) + "%");
-      System.out.println("\n\n");
-    }
-
-    done = true;
-    initialized = true;
-    return this;
   }
 
   public void initialize() {

--- a/src/main/java/io/fusionauth/load/Foreman.java
+++ b/src/main/java/io/fusionauth/load/Foreman.java
@@ -47,9 +47,7 @@ public class Foreman implements Buildable<Foreman> {
 
   public Foreman execute() throws InterruptedException {
     initialize();
-    // Note that we are going to use virtual threads, so in theory we don't need a pool, but we are trying to simulate clients or workers
-    // so keep the thread pool and just use a virtual factory.
-    try (ExecutorService pool = Executors.newFixedThreadPool(workers.size())) {
+    try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
 
       // Gradually build up workers, to reduce the chance of failures while we get going.
       for (Worker worker : workers) {

--- a/src/main/resources/Create-Applications.json
+++ b/src/main/resources/Create-Applications.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 100,
-  "workerCount": 20,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/Create-Tenants.json
+++ b/src/main/resources/Create-Tenants.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 100,
-  "workerCount": 20,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/HTTP.json
+++ b/src/main/resources/HTTP.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 500000,
-  "workerCount": 20,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.HTTPWorkerFactory",
     "attributes": {

--- a/src/main/resources/OAuth2-AuthorizationCodeGrant.json
+++ b/src/main/resources/OAuth2-AuthorizationCodeGrant.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 100,
-  "workerCount": 20,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/User-Logins.json
+++ b/src/main/resources/User-Logins.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 1000,
-  "workerCount": 50,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/User-Registrations.json
+++ b/src/main/resources/User-Registrations.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 1000,
-  "workerCount": 10,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/User-RetrieveEmail.json
+++ b/src/main/resources/User-RetrieveEmail.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 2000,
-  "workerCount": 25,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/User-Search.json
+++ b/src/main/resources/User-Search.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 2000,
-  "workerCount": 25,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/resources/User-SearchData.json
+++ b/src/main/resources/User-SearchData.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 2000,
-  "workerCount": 25,
+  "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/script/load-test.sh
+++ b/src/main/script/load-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #
-# Copyright (c) 2022, FusionAuth, All Rights Reserved
+# Copyright (c) 2022-2025, FusionAuth, All Rights Reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,4 +33,4 @@ if [[ $# > 1 && $1 == "--suspend" ]]; then
   shift
 fi
 
-~/dev/java/current17/bin/java ${suspend} -cp "${CLASSPATH}" io.fusionauth.load.LoadRunner $@
+~/dev/java/current21/bin/java ${suspend} -cp "${CLASSPATH}" io.fusionauth.load.LoadRunner $@


### PR DESCRIPTION
Switch to using virtual threads. This will allow us to push much harder on a single system. 

Example with 100 threads for login. 

```
Login
- 100 p-threads
                            Total duration:	114054 ms (~114 s)
                            Total count:		100000
                            Avg. latency:		2.052 ms
                            Avg. success:		876.778 per second

- 100 v-threads
                            Total duration:	44351 ms (~44 s)
                            Total count:		100000
                            Avg. latency:		42.931 ms
                            Avg. success:		2254.741 per second
```

This should let us push FusionAuth a lot harder- at least without having to spin up a bunch of compute to get enough threads to really push it. 

The difference is the most evident with a lot of threads because we end up just spending most of the time context switching when we run `fusionauth-app` and this load test on the same host.  FusionAuth is likely then getting starved for CPU time if the load test harness spins up that many platform threads.

This result is the Login API w/ a load factor of `1` on the password hash, so this simulates removing CPU as the bottleneck. 