### PR TITLE
add more Foreman output, java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ cd build/dist
 ./load-test.sh User-Logins.json
 ```
 
+## Tuning a Load Test
+
+The load test spins up individual Worker threads as specified in the configuration file. Each Worker synchronously makes repeated API requests. If your request latency is high (e.g., running a remote instance), this can limit your maximum potential throughput. Increasing the number of worker threads alleviates this (unless you hit local system limitations).
+
+For example, if the request latency is 250 ms and you have 10 worker threads, you'll have a max throughput of 40 requests per second. Increasing the number of worker threads to 100 increases the max throughput to 400 requests per second.
 
 ## Cleanup
 

--- a/src/main/java/io/fusionauth/load/Foreman.java
+++ b/src/main/java/io/fusionauth/load/Foreman.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2022, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,11 @@ public class Foreman implements Buildable<Foreman> {
 
   public int loopCount;
 
+  /**
+   * The number of ms to wait between starting up the workers.
+   */
+  public int rampWait;
+
   public Reporter reporter;
 
   public int workerCount;
@@ -53,6 +58,10 @@ public class Foreman implements Buildable<Foreman> {
       for (Worker worker : workers) {
         WorkerExecutor executor = new WorkerExecutor(worker, loopCount, listeners);
         pool.execute(executor);
+        try {
+          Thread.sleep(rampWait);
+        } catch (InterruptedException ignore) {
+        }
       }
 
       if (this.reporter != null) {
@@ -111,7 +120,7 @@ public class Foreman implements Buildable<Foreman> {
     }
 
     System.out.println("  --> Worker count:\t" + df.format(workerCount));
-    System.out.println("  --> Total iterations:\t" + df.format(workerCount * loopCount));
+    System.out.println("  --> Total iterations:\t" + df.format((long) workerCount * loopCount));
     System.out.println("  --> Worker factory:\t" + workerFactory.getClass().getCanonicalName());
 
     System.out.println("  --> Prepare the factory for production....");

--- a/src/main/java/io/fusionauth/load/Foreman.java
+++ b/src/main/java/io/fusionauth/load/Foreman.java
@@ -23,8 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-import io.fusionauth.client.FusionAuthClient;
-
 /**
  * @author Troy Hill
  */
@@ -78,7 +76,6 @@ public class Foreman implements Buildable<Foreman> {
       reporter.stop();
     }
 
-
     // Temp hack to get some general timings on the OAuth2 Authorize worker broken down by component
     if (workers.get(0) instanceof FusionAuthOAuth2AuthorizeWorker) {
       System.out.println("\n\n");
@@ -116,21 +113,9 @@ public class Foreman implements Buildable<Foreman> {
       throw new IllegalStateException("Please provide a worker factory if you are going to specify a worker count");
     }
 
-    String directive = null;
-    String url = null;
-    String apiKey = null;
-    if (loadDefinition != null && loadDefinition.workerFactory != null) {
-      directive = loadDefinition.workerFactory.getString("directive", null);
-      url = loadDefinition.workerFactory.getString("url", null);
-      apiKey = loadDefinition.workerFactory.getString("apiKey", null);
-    }
-
     System.out.println("  --> Worker count:\t" + df.format(workerCount));
     System.out.println("  --> Total iterations:\t" + df.format((long) workerCount * loopCount));
     System.out.println("  --> Worker factory:\t" + workerFactory.getClass().getCanonicalName());
-    System.out.println("  --> Worker directive:\t" + directive);
-    System.out.println("  --> Worker url:\t" + url);
-    System.out.println("  --> Target version:\t" + fetchVersion(url, apiKey));
 
     System.out.println("  --> Prepare the factory for production....");
     workerFactory.prepare(loadDefinition);
@@ -141,16 +126,5 @@ public class Foreman implements Buildable<Foreman> {
     if (reporter != null) {
       reporter.addSampleListeners(listeners);
     }
-  }
-
-  protected String fetchVersion(String url, String apiKey) {
-    if (apiKey != null && url != null) {
-      var client = new FusionAuthClient(apiKey, url, 5_000, 10_000);
-      var response = client.retrieveSystemStatusUsingAPIKey();
-      if (response.wasSuccessful() && response.successResponse != null) {
-        return response.successResponse.get("version").toString();
-      }
-    }
-    return "unavailable";
   }
 }

--- a/src/main/java/io/fusionauth/load/Foreman.java
+++ b/src/main/java/io/fusionauth/load/Foreman.java
@@ -116,12 +116,21 @@ public class Foreman implements Buildable<Foreman> {
       throw new IllegalStateException("Please provide a worker factory if you are going to specify a worker count");
     }
 
+    String directive = null;
+    String url = null;
+    String apiKey = null;
+    if (loadDefinition != null && loadDefinition.workerFactory != null) {
+      directive = loadDefinition.workerFactory.getString("directive", null);
+      url = loadDefinition.workerFactory.getString("url", null);
+      apiKey = loadDefinition.workerFactory.getString("apiKey", null);
+    }
+
     System.out.println("  --> Worker count:\t" + df.format(workerCount));
     System.out.println("  --> Total iterations:\t" + df.format((long) workerCount * loopCount));
     System.out.println("  --> Worker factory:\t" + workerFactory.getClass().getCanonicalName());
-    System.out.println("  --> Worker directive:\t" + loadDefinition.workerFactory.getString("directive"));
-    System.out.println("  --> Worker url:\t" + loadDefinition.workerFactory.getString("url"));
-    System.out.println("  --> Target version:\t" + fetchVersion());
+    System.out.println("  --> Worker directive:\t" + directive);
+    System.out.println("  --> Worker url:\t" + url);
+    System.out.println("  --> Target version:\t" + fetchVersion(url, apiKey));
 
     System.out.println("  --> Prepare the factory for production....");
     workerFactory.prepare(loadDefinition);
@@ -134,9 +143,7 @@ public class Foreman implements Buildable<Foreman> {
     }
   }
 
-  protected String fetchVersion() {
-    String apiKey = loadDefinition.workerFactory.getString("apiKey", null);
-    String url = loadDefinition.workerFactory.getString("url", null);
+  protected String fetchVersion(String url, String apiKey) {
     if (apiKey != null && url != null) {
       var client = new FusionAuthClient(apiKey, url, 5_000, 10_000);
       var response = client.retrieveSystemStatusUsingAPIKey();

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,5 +74,27 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
 
   @Override
   public void prepare(LoadDefinition loadDefinition) {
+    String directive = null;
+    String url = null;
+    String apiKey = null;
+    if (loadDefinition != null && loadDefinition.workerFactory != null) {
+      directive = loadDefinition.workerFactory.getString("directive", null);
+      url = loadDefinition.workerFactory.getString("url", null);
+      apiKey = loadDefinition.workerFactory.getString("apiKey", null);
+    }
+    System.out.println("  --> Worker directive:\t" + directive);
+    System.out.println("  --> Worker url:\t" + url);
+    System.out.println("  --> Target version:\t" + fetchVersion(url, apiKey));
+  }
+
+  protected String fetchVersion(String url, String apiKey) {
+    if (apiKey != null && url != null) {
+      var client = new FusionAuthClient(apiKey, url, 5_000, 10_000);
+      var response = client.retrieveSystemStatusUsingAPIKey();
+      if (response.wasSuccessful() && response.successResponse != null) {
+        return response.successResponse.get("version").toString();
+      }
+    }
+    return "unavailable";
   }
 }

--- a/src/main/java/io/fusionauth/load/JSONConfigurator.java
+++ b/src/main/java/io/fusionauth/load/JSONConfigurator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,6 @@ import java.nio.file.Paths;
 import java.security.InvalidParameterException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.fusionauth.load.Configuration;
-import io.fusionauth.load.Foreman;
-import io.fusionauth.load.LoadDefinition;
-import io.fusionauth.load.Reporter;
-import io.fusionauth.load.SampleListener;
-import io.fusionauth.load.WorkerFactory;
 import io.fusionauth.load.reporters.DefaultReporter;
 
 /**
@@ -57,7 +51,8 @@ public class JSONConfigurator {
     configureListeners();
   }
 
-  private void configureListeners() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+  private void configureListeners()
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
     for (Configuration configuration : definition.listeners) {
       Object instance = newInstance(configuration);
       if (instance instanceof SampleListener) {
@@ -68,7 +63,8 @@ public class JSONConfigurator {
     }
   }
 
-  private void configureReporter() throws InvocationTargetException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+  private void configureReporter()
+      throws InvocationTargetException, ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException {
     if (definition.reporter != null) {
       Object instance = newInstance(definition.reporter);
       if (instance instanceof Reporter) {
@@ -81,12 +77,14 @@ public class JSONConfigurator {
     }
   }
 
-  private void configureWorkerFactory() throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+  private void configureWorkerFactory()
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
     Object instance = newInstance(definition.workerFactory);
     if (instance instanceof WorkerFactory) {
       foreman.with((f) -> f.workerFactory = (WorkerFactory) instance)
              .with((f) -> f.workerCount = definition.workerCount)
-             .with((f) -> f.loopCount = definition.loopCount);
+             .with((f) -> f.loopCount = definition.loopCount)
+             .with((f) -> f.rampWait = definition.rampWait);
     } else {
       throw new IllegalArgumentException("class in configuration does not extend WorkerFactory [" + definition.workerFactory.className + ']');
     }

--- a/src/main/java/io/fusionauth/load/LoadDefinition.java
+++ b/src/main/java/io/fusionauth/load/LoadDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@ package io.fusionauth.load;
 
 import java.util.List;
 
-import io.fusionauth.load.Configuration;
-
 /**
  * @author Daniel DeGroff
  */
@@ -27,6 +25,8 @@ public class LoadDefinition extends Configuration {
   public List<Configuration> listeners;
 
   public int loopCount;
+
+  public int rampWait;
 
   public Configuration reporter;
 

--- a/src/main/resources/User-Registrations.json
+++ b/src/main/resources/User-Registrations.json
@@ -1,6 +1,7 @@
 {
   "loopCount": 1000,
   "workerCount": 100,
+  "rampWait": 9,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {

--- a/src/main/script/load-test.sh
+++ b/src/main/script/load-test.sh
@@ -33,4 +33,4 @@ if [[ $# > 1 && $1 == "--suspend" ]]; then
   shift
 fi
 
-~/dev/java/current17/bin/java ${suspend} -cp "${CLASSPATH}" io.fusionauth.load.LoadRunner $@
+~/dev/java/current21/bin/java ${suspend} -cp "${CLASSPATH}" io.fusionauth.load.LoadRunner $@

--- a/src/test/java/io/fusionauth/load/ForemanTest.java
+++ b/src/test/java/io/fusionauth/load/ForemanTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ public class ForemanTest {
                  .with((f) -> f.workerFactory = new MockWorkerFactory())
                  .with((f) -> f.listeners.add(new MockListener()))
                  .with((f) -> f.loopCount = 1)
+                 .with((f) -> f.rampWait = 10)
                  .execute();
 
     Thread.sleep(1000);


### PR DESCRIPTION
### Problem:
Running repeated load tests against remote instances can make it tricky to track which results correspond with which instance.

### Solution:
Add more output when the Forman initializes (directive, url, instance version).
```
Foreman Initialized
  --> Loop count:	1,000
  --> Worker count:	100
  --> Total iterations:	100,000
  --> Worker factory:	io.fusionauth.load.FusionAuthWorkerFactory
  --> Worker directive:	register
  --> Worker url:	https://local.fusionauth.io
  --> Target version:	1.57.1
  --> Prepare the factory for production....
```

Also, use java 21.