### PR TITLE
Add support for using Java or Restify HTTP clients

### DIFF
--- a/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
+++ b/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
@@ -24,6 +24,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.util.concurrent.Executors;
 
 import com.inversoft.rest.ClientResponse;
 import com.inversoft.rest.RESTClient;
@@ -45,6 +46,10 @@ public class JavaHTTPLoadTestWorker extends BaseWorker {
 
   private final HttpClient javaHTTPClient = HttpClient.newBuilder()
                                                       .connectTimeout(Duration.ofSeconds(10))
+                                                      // Use virtual threads
+                                                      // - This seems to improve the performance of this REST client by nearly 100%.
+                                                      //   With 100 workers, I could get ~ 25-30k RPS, with this change I can get 58k.
+                                                      .executor(Executors.newVirtualThreadPerTaskExecutor())
                                                       .followRedirects(Redirect.ALWAYS)
                                                       .build();
 

--- a/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
+++ b/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,14 @@
  */
 package io.fusionauth.load;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Redirect;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
+
 import com.inversoft.rest.ByteArrayBodyHandler;
 import com.inversoft.rest.ClientResponse;
 import com.inversoft.rest.RESTClient;
@@ -26,25 +34,62 @@ import com.inversoft.rest.TextResponseHandler;
  * @author Daniel DeGroff
  */
 public class JavaHTTPLoadTestWorker extends BaseWorker {
+  private final HttpClient javaHTTPClient = HttpClient.newBuilder()
+                                                      .connectTimeout(Duration.ofSeconds(10))
+                                                      .followRedirects(Redirect.ALWAYS)
+                                                      .build();
+
+  private final String restClient;
+
   private final String url;
 
   public JavaHTTPLoadTestWorker(Configuration configuration) {
     super(configuration);
     this.url = configuration.getString("url");
+    this.restClient = configuration.getString("restClient");
   }
 
   @Override
   public boolean execute() {
-    ClientResponse<String, String> response = new RESTClient<>(String.class, String.class)
-        .url(this.url)
-        .bodyHandler(new ByteArrayBodyHandler("This is a body that is hashed".getBytes()))
-        .connectTimeout(7_000)
-        .readTimeout(7_000)
-        .successResponseHandler(new TextResponseHandler())
-        .errorResponseHandler(new TextResponseHandler())
-        .get()
-        .go();
-    return response.wasSuccessful();
+    if ("restify".equals(restClient)) {
+      ClientResponse<String, String> response = new RESTClient<>(String.class, String.class)
+          .url(this.url)
+          .setHeader("Content-Type", "text/plain")
+          .bodyHandler(new ByteArrayBodyHandler("This is a body that is hashed".getBytes()))
+          .connectTimeout(15_000)
+          .readTimeout(15_000)
+          .successResponseHandler(new TextResponseHandler())
+          .errorResponseHandler(new TextResponseHandler())
+          .get()
+          .go();
+
+      if (response.wasSuccessful()) {
+        return true;
+      }
+
+      if (response.exception != null) {
+        System.out.println(response.exception.getClass().getSimpleName() + " [" + response.exception.getMessage() + "]");
+      } else {
+        System.out.println(response.status);
+        System.out.println(response.errorResponse);
+      }
+      return false;
+    } else if ("java".equals(restClient)) {
+      var request = HttpRequest.newBuilder()
+                               .method("GET", BodyPublishers.ofByteArray("This is a body that is hashed".getBytes()))
+                               .timeout(Duration.ofSeconds(10))
+                               .uri(URI.create(this.url))
+                               .build();
+
+      try {
+        var response = javaHTTPClient.send(request, BodyHandlers.ofByteArray());
+        return response.statusCode() >= 200 && response.statusCode() <= 399;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("Unknown value [" + restClient + "] for [restClient]. Supported values include [restify, java]. Default is restify.");
   }
 
   @Override

--- a/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
+++ b/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
@@ -60,14 +60,16 @@ public class JavaHTTPLoadTestWorker extends BaseWorker {
     }
 
     // Build a single REST client for this worker.
-    javaRESTClient = HttpClient.newBuilder()
-                               .connectTimeout(Duration.ofSeconds(10))
-                               // Use virtual threads
-                               // - This seems to improve the performance of this REST client by nearly 100%.
-                               //   With 100 workers, I could get ~ 25-30k RPS, with this change I can get 58k.
-                               .executor(Executors.newVirtualThreadPerTaskExecutor())
-                               .followRedirects(Redirect.ALWAYS)
-                               .build();
+    javaRESTClient = restClient.equals("java")
+        ? HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(10))
+                    // Use virtual threads
+                    // - This seems to improve the performance of this REST client by nearly 100%.
+                    //   With 100 workers, I could get ~ 25-30k RPS, with this change I can get 58k.
+                    .executor(Executors.newVirtualThreadPerTaskExecutor())
+                    .followRedirects(Redirect.ALWAYS)
+                    .build()
+        : null;
   }
 
   @Override
@@ -114,7 +116,8 @@ public class JavaHTTPLoadTestWorker extends BaseWorker {
       }
     }
 
-    throw new IllegalStateException("Unknown value [" + restClient + "] for [restClient]. Supported values include [restify, java]. Default is restify.");
+    // Note, this is not expected since we are validating this in the constructor.
+    return false;
   }
 
   @Override

--- a/src/main/java/io/fusionauth/load/http/ChunkedBodyHandler.java
+++ b/src/main/java/io/fusionauth/load/http/ChunkedBodyHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.load.http;
+
+import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
+
+import com.inversoft.rest.ByteArrayBodyHandler;
+
+/**
+ * A simple Chunked body handler.
+ *
+ * @author Daniel DeGroff
+ */
+public class ChunkedBodyHandler extends ByteArrayBodyHandler {
+  private int chunkSize = 1024;
+
+  public ChunkedBodyHandler(String body) {
+    super(body.getBytes(StandardCharsets.UTF_8));
+  }
+
+  @Override
+  public void setHeaders(HttpURLConnection huc) {
+    if (chunkSize == 0) {
+      throw new IllegalStateException("chunkSize must be greater than 0");
+    }
+    huc.setChunkedStreamingMode(chunkSize);
+  }
+
+  public ChunkedBodyHandler withChunkSize(int chunkSize) {
+    this.chunkSize = chunkSize;
+    return this;
+  }
+}

--- a/src/main/java/io/fusionauth/load/http/FixedLengthRequestHandler.java
+++ b/src/main/java/io/fusionauth/load/http/FixedLengthRequestHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.load.http;
+
+import java.nio.charset.StandardCharsets;
+
+import com.inversoft.rest.ByteArrayBodyHandler;
+
+/**
+ * A simple Fixed Length body handler.
+ *
+ * @author Daniel DeGroff
+ */
+public class FixedLengthRequestHandler extends ByteArrayBodyHandler {
+  public FixedLengthRequestHandler(String body) {
+    super(body.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/resources/HTTP.json
+++ b/src/main/resources/HTTP.json
@@ -1,11 +1,12 @@
 {
-  "loopCount": 500000,
+  "loopCount": 100000,
   "workerCount": 100,
   "workerFactory": {
     "className": "io.fusionauth.load.HTTPWorkerFactory",
     "attributes": {
       "directive": "java-http-load-test",
-      "url": "http://localhost:8080/load"
+      "url": "http://localhost:8080/",
+      "restClient": "restify"
     }
   },
   "listeners": [

--- a/src/main/resources/HTTP.json
+++ b/src/main/resources/HTTP.json
@@ -6,7 +6,8 @@
     "attributes": {
       "directive": "java-http-load-test",
       "url": "http://localhost:8080/",
-      "restClient": "restify"
+      "restClient": "restify",
+      "chunked": false
     }
   },
   "listeners": [


### PR DESCRIPTION
### Summary 
Doing some work with loading testing in `java-http`. This adds support to allow the test definition to swap between the Java REST client and ours (Restify) easily. 

This is useful to see the difference in performance. 

### Related 
- https://github.com/FusionAuth/java-http/pull/33