### PR TITLE
Handle consent

### DIFF
--- a/src/main/java/io/fusionauth/load/FusionAuthOAuth2AuthorizeWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthOAuth2AuthorizeWorker.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import com.inversoft.http.Cookie;
 import com.inversoft.rest.ClientResponse;
 import com.inversoft.rest.FormDataBodyHandler;
 import com.inversoft.rest.RESTClient;
@@ -130,16 +129,11 @@ public class FusionAuthOAuth2AuthorizeWorker extends BaseWorker {
 
           // Handle consent
           if (location.startsWith("/oauth2/consent")) {
-            Cookie loginIntent = postResponse.getCookies()
-                                             .stream()
-                                             .filter(c -> c.name.equals("fusionauth.li"))
-                                             .findFirst()
-                                             .orElseThrow();
-
             ClientResponse<Void, Void> consentResponse = new RESTClient<>(Void.TYPE, Void.TYPE)
                 .url(this.baseURL + location)
                 .followRedirects(false)
-                .cookie(loginIntent)
+                // Make sure we pick up the fusionauth.li cookie
+                .cookies(postResponse.getCookies())
                 .connectTimeout(7_000)
                 .readTimeout(7_000)
                 .get()

--- a/src/main/resources/OAuth2-AuthorizationCodeGrant.json
+++ b/src/main/resources/OAuth2-AuthorizationCodeGrant.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 100,
-  "workerCount": 100,
+  "workerCount": 25,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {


### PR DESCRIPTION
Update the Auth Code workflow test to handle the consent page. 

Ideally this workload doesn't need to know the version of `fusionauth-app` so I am not making the assumption that this redirect will always occur.