### PR TITLE
ENG-2230 Bump restify to pick up a fix for the reported issue in FusionAuth.

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, FusionAuth, All Rights Reserved
+ * Copyright (c) 2018-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ jacksonVersion = "2.15.4"
 jackson5Version = "3.0.1"
 javaErrorVersion = "2.2.3"
 logbackVersion = "1.5.6"
-restifyVersion = "4.2.1"
+restifyVersion = "4.3.0-{integration}"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 

--- a/build.savant
+++ b/build.savant
@@ -22,7 +22,7 @@ jacksonVersion = "2.15.4"
 jackson5Version = "3.0.1"
 javaErrorVersion = "2.2.3"
 logbackVersion = "1.5.6"
-restifyVersion = "4.3.0-{integration}"
+restifyVersion = "4.3.0"
 slf4jVersion = "2.0.13"
 testngVersion = "7.8.0"
 

--- a/fusionauth-load-tests.iml
+++ b/fusionauth-load-tests.iml
@@ -40,11 +40,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.2.1/restify-4.2.1.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.2.1/restify-4.2.1-src.jar!/" />
+          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/fusionauth-load-tests.iml
+++ b/fusionauth-load-tests.iml
@@ -40,11 +40,11 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.3.0/restify-4.3.0.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$USER_HOME$/.savant/cache/com/inversoft/restify/4.3.0-{integration}/restify-4.3.0-{integration}-src.jar!/" />
+          <root url="jar://$MODULE_DIR$/.savant/cache/com/inversoft/restify/4.3.0/restify-4.3.0-src.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>


### PR DESCRIPTION
### Issue:
- https://github.com/FusionAuth/fusionauth-issues/issues/2978
- https://linear.app/fusionauth/issue/ENG-2230/oidc-providers-which-set-cookies-ending-with-a-semicolon-could-be

### Summary
Sync up version of restify with `fusionauth-app` see related PR. 

### Linked PRs
- https://github.com/fusionauth-eng/fusionauth-app/pull/898
- https://github.com/inversoft/restify/pull/14
