### PR TITLE
load tests add user import and update password

### DIFF
--- a/src/main/java/io/fusionauth/load/BaseWorker.java
+++ b/src/main/java/io/fusionauth/load/BaseWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2024, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,14 @@ public abstract class BaseWorker implements Worker {
     }
 
     return sb.substring(0, length);
+  }
+
+  @Override
+  public void finished() {
+  }
+
+  @Override
+  public void prepare() {
   }
 
   void printErrors(ClientResponse<?, Errors> result) {

--- a/src/main/java/io/fusionauth/load/ElasticsearchWorker.java
+++ b/src/main/java/io/fusionauth/load/ElasticsearchWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2023-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,13 +82,5 @@ public class ElasticsearchWorker extends BaseWorker {
     }
 
     return response.wasSuccessful();
-  }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthBaseWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthBaseWorker.java
@@ -87,5 +87,4 @@ public abstract class FusionAuthBaseWorker extends BaseWorker {
       setApplicationIndex(applicationIndex);
     }
   }
-
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthBaseWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthBaseWorker.java
@@ -25,11 +25,11 @@ import io.fusionauth.client.FusionAuthClient;
  * @author Brent Halsey
  */
 public abstract class FusionAuthBaseWorker extends BaseWorker {
+  protected final int applicationCount;
+
   protected final FusionAuthClient client;
 
-  private final int applicationCount;
-
-  private final int tenantCount;
+  protected final int tenantCount;
 
   protected UUID applicationId;
 

--- a/src/main/java/io/fusionauth/load/FusionAuthCreateApplicationWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthCreateApplicationWorker.java
@@ -52,12 +52,4 @@ public class FusionAuthCreateApplicationWorker extends FusionAuthBaseWorker {
     printErrors(result);
     return false;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthCreateTenantWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthCreateTenantWorker.java
@@ -24,6 +24,7 @@ import io.fusionauth.client.FusionAuthClient;
 import io.fusionauth.domain.RefreshTokenExpirationPolicy;
 import io.fusionauth.domain.RefreshTokenRevocationPolicy;
 import io.fusionauth.domain.RefreshTokenUsagePolicy;
+import io.fusionauth.domain.RememberPreviousPasswords;
 import io.fusionauth.domain.SecureGeneratorConfiguration;
 import io.fusionauth.domain.SecureGeneratorType;
 import io.fusionauth.domain.Tenant;
@@ -44,6 +45,10 @@ public class FusionAuthCreateTenantWorker extends FusionAuthBaseWorker {
   @Override
   public boolean execute() {
     setTenantIndex(counter.incrementAndGet());
+
+    RememberPreviousPasswords rememberPreviousPasswords = new RememberPreviousPasswords();
+    rememberPreviousPasswords.enabled = true;
+    rememberPreviousPasswords.count = 100;
 
     Tenant tenant = new Tenant().with(t -> t.name = "tenant_" + tenantIndex)
                                 .with(t -> t.emailConfiguration.verifyEmail = false) // Verifying email in load test can harm your email reputation
@@ -75,6 +80,7 @@ public class FusionAuthCreateTenantWorker extends FusionAuthBaseWorker {
                                 .with(t -> t.jwtConfiguration.refreshTokenTimeToLiveInMinutes = 60)
                                 .with(t -> t.jwtConfiguration.refreshTokenUsagePolicy = RefreshTokenUsagePolicy.OneTimeUse)
                                 .with(t -> t.jwtConfiguration.timeToLiveInSeconds = 60)
+                                .with(t -> t.passwordValidationRules.rememberPreviousPasswords = rememberPreviousPasswords)
                                 .with(t -> t.passwordValidationRules.maxLength = 200)
                                 .with(t -> t.passwordValidationRules.minLength = 10)
                                 .with(t -> t.passwordValidationRules.requireMixedCase = false)

--- a/src/main/java/io/fusionauth/load/FusionAuthCreateTenantWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthCreateTenantWorker.java
@@ -96,12 +96,4 @@ public class FusionAuthCreateTenantWorker extends FusionAuthBaseWorker {
     printErrors(result);
     return false;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthEmailVerificationIdWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthEmailVerificationIdWorker.java
@@ -42,12 +42,4 @@ public class FusionAuthEmailVerificationIdWorker extends FusionAuthBaseWorker {
     ClientResponse<VerifyEmailResponse, Void> result = tenantScopedClient.generateEmailVerificationId(email);
     return result.wasSuccessful();
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthLoginWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthLoginWorker.java
@@ -64,12 +64,4 @@ public class FusionAuthLoginWorker extends FusionAuthBaseWorker {
     printErrors(result);
     return false;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthOAuth2AuthorizeWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthOAuth2AuthorizeWorker.java
@@ -182,14 +182,6 @@ public class FusionAuthOAuth2AuthorizeWorker extends BaseWorker {
     return false;
   }
 
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
-
   public static class OAUth2Timing {
     public long post;
 

--- a/src/main/java/io/fusionauth/load/FusionAuthRefreshWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthRefreshWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, FusionAuth, All Rights Reserved
+ * Copyright (c) 2024-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,13 +72,5 @@ public class FusionAuthRefreshWorker extends BaseWorker {
 
     printErrors(result);
     return false;
-  }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthRegistrationWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthRegistrationWorker.java
@@ -75,12 +75,4 @@ public class FusionAuthRegistrationWorker extends FusionAuthBaseWorker {
     printErrors(result);
     return false;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthRetrieveEmailWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthRetrieveEmailWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2023-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,13 +53,5 @@ public class FusionAuthRetrieveEmailWorker extends BaseWorker {
 
     printErrors(result);
     return false;
-  }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthSearchDataWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthSearchDataWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2023-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,13 +65,5 @@ public class FusionAuthSearchDataWorker extends BaseWorker {
 
     printErrors(result);
     return false;
-  }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthSearchWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthSearchWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, FusionAuth, All Rights Reserved
+ * Copyright (c) 2023-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,13 +64,5 @@ public class FusionAuthSearchWorker extends BaseWorker {
 
     printErrors(result);
     return false;
-  }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthSimpleGetWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthSimpleGetWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2020, FusionAuth, All Rights Reserved
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,13 +42,5 @@ public class FusionAuthSimpleGetWorker extends BaseWorker {
         .get()
         .go();
     return getResponse.wasSuccessful();
-  }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthUpdatePasswordWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthUpdatePasswordWorker.java
@@ -64,12 +64,4 @@ public class FusionAuthUpdatePasswordWorker extends FusionAuthBaseWorker {
 
     return false;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthUpdatePasswordWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthUpdatePasswordWorker.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.load;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import com.inversoft.error.Errors;
+import com.inversoft.rest.ClientResponse;
+import io.fusionauth.client.FusionAuthClient;
+import io.fusionauth.domain.api.UserResponse;
+
+/**
+ * Worker to test logins.
+ *
+ * @author Daniel DeGroff
+ */
+public class FusionAuthUpdatePasswordWorker extends FusionAuthBaseWorker {
+  private final UUID configuredApplicationId;
+
+  private final int loginLowerBound;
+
+  private final int loginUpperBound;
+
+  public FusionAuthUpdatePasswordWorker(FusionAuthClient client, Configuration configuration) {
+    super(client, configuration);
+    if (configuration.hasProperty("applicationId")) {
+      this.configuredApplicationId = UUID.fromString(configuration.getString("applicationId"));
+    } else {
+      this.configuredApplicationId = null;
+    }
+    this.loginLowerBound = configuration.getInteger("loginLowerBound", 0);
+    this.loginUpperBound = configuration.getInteger("loginUpperBound", 1_000_000);
+  }
+
+  @Override
+  public boolean execute() {
+    // Pick a random user to log in
+    int index = new Random().nextInt((loginUpperBound - loginLowerBound) + 1) + loginLowerBound;
+    setUserIndex(index);
+    String email = "load_user_" + userIndex + "@fusionauth.io";
+
+    String newPassword = "password_" + new Random().nextInt(1_000_000);
+    ClientResponse<UserResponse, Errors> result = tenantScopedClient.retrieveUserByEmail(email);
+    if (result.wasSuccessful()) {
+      ClientResponse<UserResponse, Errors> patchResult = tenantScopedClient.patchUser(result.successResponse.user.id, Map.of("user", Map.of("password", newPassword)));
+      if (patchResult.wasSuccessful()) {
+        return true;
+      } else {
+        System.err.println("Failed to update password for user: " + email);
+        printErrors(patchResult);
+      }
+    } else {
+      System.err.println("Failed to retrieve user: " + email);
+      printErrors(result);
+    }
+
+    return false;
+  }
+
+  @Override
+  public void finished() {
+  }
+
+  @Override
+  public void prepare() {
+  }
+}

--- a/src/main/java/io/fusionauth/load/FusionAuthUpdatePasswordWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthUpdatePasswordWorker.java
@@ -17,7 +17,6 @@ package io.fusionauth.load;
 
 import java.util.Map;
 import java.util.Random;
-import java.util.UUID;
 
 import com.inversoft.error.Errors;
 import com.inversoft.rest.ClientResponse;
@@ -25,24 +24,18 @@ import io.fusionauth.client.FusionAuthClient;
 import io.fusionauth.domain.api.UserResponse;
 
 /**
- * Worker to test logins.
+ * Worker to test updating passwords for users. This can be useful for generating a lot of previous passwords
+ * (if the tenant is configured to store previous passwords).
  *
- * @author Daniel DeGroff
+ * @author Brent Halsey
  */
 public class FusionAuthUpdatePasswordWorker extends FusionAuthBaseWorker {
-  private final UUID configuredApplicationId;
-
   private final int loginLowerBound;
 
   private final int loginUpperBound;
 
   public FusionAuthUpdatePasswordWorker(FusionAuthClient client, Configuration configuration) {
     super(client, configuration);
-    if (configuration.hasProperty("applicationId")) {
-      this.configuredApplicationId = UUID.fromString(configuration.getString("applicationId"));
-    } else {
-      this.configuredApplicationId = null;
-    }
     this.loginLowerBound = configuration.getInteger("loginLowerBound", 0);
     this.loginUpperBound = configuration.getInteger("loginUpperBound", 1_000_000);
   }

--- a/src/main/java/io/fusionauth/load/FusionAuthUserImportWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthUserImportWorker.java
@@ -28,9 +28,9 @@ import io.fusionauth.domain.UserRegistration;
 import io.fusionauth.domain.api.user.ImportRequest;
 
 /**
- * Worker to test creating users and registrations. The user data includes a randomly generated external Id.
+ * Worker to test importing users
  *
- * @author Daniel DeGroff
+ * @author Brent Halsey
  */
 public class FusionAuthUserImportWorker extends FusionAuthBaseWorker {
   private final int batchSize;
@@ -78,7 +78,6 @@ public class FusionAuthUserImportWorker extends FusionAuthBaseWorker {
                                                                   .with(r -> r.roles.add("user"));
         user.getRegistrations().add(userRegistration);
         users.add(user);
-
       }
 
       ClientResponse<Void, Errors> result = tenantScopedClient.importUsers(new ImportRequest(users));

--- a/src/main/java/io/fusionauth/load/FusionAuthUserImportWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthUserImportWorker.java
@@ -91,12 +91,4 @@ public class FusionAuthUserImportWorker extends FusionAuthBaseWorker {
     counter.addAndGet(batchSize * tenantCount);
     return true;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthUserImportWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthUserImportWorker.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.load;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.inversoft.error.Errors;
+import com.inversoft.rest.ClientResponse;
+import io.fusionauth.client.FusionAuthClient;
+import io.fusionauth.domain.User;
+import io.fusionauth.domain.UserRegistration;
+import io.fusionauth.domain.api.user.ImportRequest;
+
+/**
+ * Worker to test creating users and registrations. The user data includes a randomly generated external Id.
+ *
+ * @author Daniel DeGroff
+ */
+public class FusionAuthUserImportWorker extends FusionAuthBaseWorker {
+  private final int batchSize;
+
+  private final UUID configuredApplicationId;
+
+  private final AtomicInteger counter;
+
+  private final int factor;
+
+  public FusionAuthUserImportWorker(FusionAuthClient client, Configuration configuration, AtomicInteger counter) {
+    super(client, configuration);
+    this.counter = counter;
+    if (configuration.hasProperty("applicationId")) {
+      this.configuredApplicationId = UUID.fromString(configuration.getString("applicationId"));
+    } else {
+      this.configuredApplicationId = null;
+    }
+    this.batchSize = configuration.getInteger("batchSize");
+    this.factor = configuration.getInteger("factor");
+  }
+
+  @Override
+  public boolean execute() {
+
+    int offset = counter.get(); // Only run this single thread/worker
+    System.out.println("Importing users with offset: " + offset);
+
+    // do a batch for each tenant. ti = tenant index
+    for (int ti = 1; ti <= tenantCount; ti++) {
+      List<User> users = new ArrayList<>();
+      for (int j = 0; j < batchSize; j++) {
+        setUserIndex(offset + ti + j * tenantCount);
+
+        User user = new User();
+        user.active = true;
+        user.email = "load_user_" + userIndex + "@fusionauth.io";
+        user.password = Password;
+        user.factor = factor;
+        user.data.put("externalId", secureString(20, ALPHA_NUMERIC_CHARACTERS));
+        user.tenantId = tenantId;
+
+        UUID registrationAppId = configuredApplicationId != null ? configuredApplicationId : applicationId;
+        UserRegistration userRegistration = new UserRegistration().with(r -> r.applicationId = registrationAppId)
+                                                                  .with(r -> r.roles.add("user"));
+        user.getRegistrations().add(userRegistration);
+        users.add(user);
+
+      }
+
+      ClientResponse<Void, Errors> result = tenantScopedClient.importUsers(new ImportRequest(users));
+      if (!result.wasSuccessful()) {
+        // keep going if we have an error, but log it
+        printErrors(result);
+      } else {
+        System.out.println("Imported " + users.size() + " users for tenant " + tenantIndex);
+      }
+    }
+    counter.addAndGet(batchSize * tenantCount);
+    return true;
+  }
+
+  @Override
+  public void finished() {
+  }
+
+  @Override
+  public void prepare() {
+  }
+}

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -63,6 +63,7 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
       case "email-verification" -> new FusionAuthEmailVerificationIdWorker(client, configuration, counter);
       case "simple-get" -> new FusionAuthSimpleGetWorker(configuration);
       case "login" -> new FusionAuthLoginWorker(client, configuration);
+      case "update-password" -> new FusionAuthUpdatePasswordWorker(client, configuration);
       case "oauth2/authorize" -> new FusionAuthOAuth2AuthorizeWorker(client, configuration);
       case "refresh" -> new FusionAuthRefreshWorker(client, configuration);
       case "register" -> new FusionAuthRegistrationWorker(client, configuration, counter);

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -70,6 +70,7 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
       case "search" -> new FusionAuthSearchWorker(client, configuration);
       case "search-data" -> new FusionAuthSearchDataWorker(client, configuration);
       case "retrieve-email" -> new FusionAuthRetrieveEmailWorker(client, configuration);
+      case "user-import" -> new FusionAuthUserImportWorker(client, configuration, counter);
       case "elasticsearch" -> new ElasticsearchWorker(configuration);
       default -> throw new IllegalArgumentException("Invalid directive [" + directive + "]");
     };

--- a/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
+++ b/src/main/java/io/fusionauth/load/JavaHTTPLoadTestWorker.java
@@ -119,12 +119,4 @@ public class JavaHTTPLoadTestWorker extends BaseWorker {
     // Note, this is not expected since we are validating this in the constructor.
     return false;
   }
-
-  @Override
-  public void finished() {
-  }
-
-  @Override
-  public void prepare() {
-  }
 }

--- a/src/main/resources/User-Import-MultiTenant.json
+++ b/src/main/resources/User-Import-MultiTenant.json
@@ -1,0 +1,31 @@
+{
+  "loopCount": 5,
+  "workerCount": 1,
+  "rampWait": 9,
+  "workerFactory": {
+    "className": "io.fusionauth.load.FusionAuthWorkerFactory",
+    "attributes": {
+      "directive": "user-import",
+      "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
+      "url": "https://local.fusionauth.io",
+      "counter": 1,
+      "encryptionScheme": "salted-pbkdf2-hmac-sha256",
+      "factor": 1,
+      "debug": true,
+      "applicationCount": 1000,
+      "tenantCount": 10,
+      "batchSize": 1000
+    }
+  },
+  "listeners": [
+    {
+      "className": "io.fusionauth.load.listeners.ThroughputListener"
+    }
+  ],
+  "reporter": {
+    "className": "io.fusionauth.load.reporters.DefaultReporter",
+    "attributes": {
+      "interval": 5
+    }
+  }
+}

--- a/src/main/resources/User-UpdatePassword-MultiTenant.json
+++ b/src/main/resources/User-UpdatePassword-MultiTenant.json
@@ -1,0 +1,28 @@
+{
+  "loopCount": 1000,
+  "workerCount": 100,
+  "workerFactory": {
+    "className": "io.fusionauth.load.FusionAuthWorkerFactory",
+    "attributes": {
+      "directive": "update-password",
+      "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
+      "url": "https://local.fusionauth.io",
+      "loginLowerBound": 1,
+      "loginUpperBound": 100000,
+      "debug": true,
+      "applicationCount": 1000,
+      "tenantCount": 10
+    }
+  },
+  "listeners": [
+    {
+      "className": "io.fusionauth.load.listeners.ThroughputListener"
+    }
+  ],
+  "reporter": {
+    "className": "io.fusionauth.load.reporters.DefaultReporter",
+    "attributes": {
+      "interval": 5
+    }
+  }
+}


### PR DESCRIPTION
### Issue:
(was related to)
- https://linear.app/fusionauth/issue/ENG-2489/the-createbulk-api-contributes-to-heavy-database-load

### Problem:
* We want to load test user imports. And have an easy way to create user import requests distributed across many applications and tenants
* We want to load an instance with previous passwords

### Solution:
* Add new workers to the load tests

