### PR TITLE
Bhalsey/eng 3965 reproduce patch race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ai
 *.iws
 build
 error-log.txt

--- a/src/main/java/io/fusionauth/load/BaseWorker.java
+++ b/src/main/java/io/fusionauth/load/BaseWorker.java
@@ -34,7 +34,7 @@ public abstract class BaseWorker implements Worker {
 
   final Configuration configuration;
 
-  private final boolean debug;
+  protected final boolean debug;
 
   protected BaseWorker(Configuration configuration) {
     this.debug = configuration.getBoolean("debug", false);

--- a/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
@@ -15,7 +15,6 @@
  */
 package io.fusionauth.load;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -65,14 +64,13 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
     setApplicationIndex(counter.incrementAndGet());
 
     Map<String, Object> patch = Map.of("identityProvider",
-                                       List.of(
                                            Map.of("applicationConfiguration",
                                                   Map.of(applicationId.toString(),
-                                                         Map.of("createRegistration", Boolean.TRUE, "enabled", Boolean.TRUE))),
-                                           Map.of("tenantConfiguration",
+                                                         Map.of("createRegistration", Boolean.TRUE, "enabled", Boolean.TRUE)),
+                                           "tenantConfiguration",
                                                   Map.of(tenantId.toString(),
                                                          Map.of("limitUserLinkCount",
-                                                                Map.of("maximumLinks", 42, "enabled", Boolean.TRUE))))));
+                                                                Map.of("maximumLinks", 42, "enabled", Boolean.TRUE)))));
     ClientResponse<IdentityProviderResponse, Errors> result = retryablePatch(idpId, patch);
     if (result.wasSuccessful()) {
       return true;

--- a/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
@@ -84,13 +84,12 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
 
   // Do our own retry logic (until we add retry support in the java client)
   private ClientResponse<IdentityProviderResponse, Errors> retryablePatch(UUID idpId, Map<String, Object> patch, int attempt) {
-
     ClientResponse<IdentityProviderResponse, Errors> result = client.patchIdentityProvider(idpId, patch);
     if (result.wasSuccessful() || attempt == maxAttempts) {
       return result;
     } else if (result.status == 409) {
       try {
-        long backoff = 500L * attempt;
+        long backoff = (long) (500 * Math.pow(1.5, attempt));
         long jitter = (long) (Math.random() * 0.10 * backoff);
         System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying\n", attempt, backoff, jitter);
         Thread.sleep(backoff + jitter);

--- a/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.load;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.inversoft.error.Errors;
+import com.inversoft.rest.ClientResponse;
+import io.fusionauth.client.FusionAuthClient;
+import io.fusionauth.domain.api.IdentityProviderResponse;
+
+/**
+ * Makes a PATCH /api/identity-provider/{idpId} call, enabling the identity provider for
+ * the application corresponding to the counter.
+ * <br/>
+ * You likely want to reset the idp after a load test to clear the enabled applications.
+ * Counting the applications provides a count of successful calls.
+ * E.g.,
+ * <pre>
+ *   curl -s https://local.fusionauth.io/api/identity-provider/{idpId} -H "Authorization: {api_key}" | jq '.identityProvider.applicationConfiguration | length'
+ * </pre>
+ *
+ * @author Brent Halsey
+ */
+public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker {
+  private final AtomicInteger counter;
+
+  private final UUID idpId;
+
+  private final int maxAttempts;
+
+  public FusionAuthPatchIdentityProviderWorker(FusionAuthClient client, Configuration configuration, AtomicInteger counter) {
+    super(client, configuration);
+    this.counter = counter;
+    if (configuration.hasProperty("idpId")) {
+      this.idpId = UUID.fromString(configuration.getString("idpId"));
+    } else {
+      this.idpId = null;
+    }
+    this.maxAttempts = configuration.getInteger("maxAttempts", 10);
+  }
+
+  @Override
+  public boolean execute() {
+    setApplicationIndex(counter.incrementAndGet());
+
+    Map<String, Object> patch = Map.of("identityProvider",
+                                       Map.of("applicationConfiguration",
+                                              Map.of(applicationId.toString(),
+                                                     Map.of("createRegistration", Boolean.TRUE, "enabled", Boolean.TRUE))));
+    ClientResponse<IdentityProviderResponse, Errors> result = retryablePatch(idpId, patch);
+    if (result.wasSuccessful()) {
+      return true;
+    }
+
+    printErrors(result);
+    return false;
+  }
+
+  private ClientResponse<IdentityProviderResponse, Errors> retryablePatch(UUID idpId, Map<String, Object> patch) {
+    return retryablePatch(idpId, patch, 1);
+  }
+
+  // Do our own retry logic (until we add retry support in the java client)
+  private ClientResponse<IdentityProviderResponse, Errors> retryablePatch(UUID idpId, Map<String, Object> patch, int attempt ) {
+
+    ClientResponse<IdentityProviderResponse, Errors> result = client.patchIdentityProvider(idpId, patch);
+    if (result.wasSuccessful() || attempt == maxAttempts) {
+      return result;
+    } else if (result.status == 409) {
+      try {
+        long backoff = 500L * attempt;
+        long jitter = (long) (Math.random() * 0.10 * backoff);
+        System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying\n", attempt, backoff, jitter);
+        Thread.sleep(backoff + jitter);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+      return retryablePatch(idpId, patch, attempt + 1);
+    } else {
+      printErrors(result);
+      return result;
+    }
+  }
+}

--- a/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPatchIdentityProviderWorker.java
@@ -48,10 +48,14 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
   public FusionAuthPatchIdentityProviderWorker(FusionAuthClient client, Configuration configuration, AtomicInteger counter) {
     super(client, configuration);
     this.counter = counter;
-    if (configuration.hasProperty("idpId")) {
-      this.idpId = UUID.fromString(configuration.getString("idpId"));
-    } else {
-      this.idpId = null;
+    if (!configuration.hasProperty("idpId")) {
+      throw new IllegalArgumentException("The 'idpId' configuration property is required for FusionAuthPatchIdentityProviderWorker.");
+    }
+    String idpIdString = configuration.getString("idpId");
+    try {
+      this.idpId = UUID.fromString(idpIdString);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("The 'idpId' configuration property must be a valid UUID. Value was: " + idpIdString, e);
     }
     this.maxAttempts = configuration.getInteger("maxAttempts", 10);
   }
@@ -91,14 +95,16 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
       try {
         long backoff = (long) (500 * Math.pow(1.5, attempt));
         long jitter = (long) (Math.random() * 0.10 * backoff);
-        System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying\n", attempt, backoff, jitter);
+        if (debug) {
+          System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying\n", attempt, backoff, jitter);
+        }
         Thread.sleep(backoff + jitter);
       } catch (InterruptedException e) {
-        throw new RuntimeException(e);
+        Thread.currentThread().interrupt();
+        return result;
       }
       return retryablePatch(idpId, patch, attempt + 1);
     } else {
-      printErrors(result);
       return result;
     }
   }

--- a/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
@@ -15,7 +15,6 @@
  */
 package io.fusionauth.load;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -61,14 +60,14 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
     setApplicationIndex(counter.incrementAndGet());
 
     Map<String, Object> patch = Map.of("identityProvider",
-                                       List.of(
-                                           Map.of("applicationConfiguration",
-                                                  Map.of(applicationId.toString(),
-                                                         Map.of("createRegistration", Boolean.TRUE, "enabled", Boolean.TRUE))),
-                                           Map.of("tenantConfiguration",
-                                                  Map.of(tenantId.toString(),
-                                                         Map.of("limitUserLinkCount",
-                                                                Map.of("maximumLinks", 42, "enabled", Boolean.TRUE))))));
+                                       Map.of("tenantConfiguration",
+                                              Map.of(tenantId.toString(),
+                                                     Map.of("limitUserLinkCount",
+                                                            Map.of("maximumLinks", 42, "enabled", Boolean.TRUE)))));
+//    Map<String, Object> patch = Map.of("identityProvider",
+//                                       Map.of("applicationConfiguration",
+//                                              Map.of(applicationId.toString(),
+//                                                     Map.of("createRegistration", Boolean.TRUE, "enabled", Boolean.TRUE))));
     ClientResponse<IdentityProviderResponse, Errors> result = retryablePatch(idpId, patch);
     if (result.wasSuccessful()) {
       return true;

--- a/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
@@ -15,36 +15,47 @@
  */
 package io.fusionauth.load;
 
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import com.inversoft.error.Errors;
 import com.inversoft.rest.ClientResponse;
 import io.fusionauth.client.FusionAuthClient;
+import io.fusionauth.domain.api.IdentityProviderRequest;
 import io.fusionauth.domain.api.IdentityProviderResponse;
+import io.fusionauth.domain.provider.IdentityProviderLimitUserLinkingPolicy;
+import io.fusionauth.domain.provider.IdentityProviderLinkingStrategy;
+import io.fusionauth.domain.provider.IdentityProviderOauth2Configuration;
+import io.fusionauth.domain.provider.IdentityProviderTenantConfiguration;
+import io.fusionauth.domain.provider.OpenIdConnectApplicationConfiguration;
+import io.fusionauth.domain.provider.OpenIdConnectIdentityProvider;
 
 /**
- * Makes a PATCH /api/identity-provider/{idpId} call, enabling the identity provider for
- * the application corresponding to the counter.
- * <br/>
- * You likely want to reset the idp after a load test to clear the enabled applications.
- * Counting the applications provides a count of successful calls.
- * E.g.,
- * <pre>
- *   curl -s https://local.fusionauth.io/api/identity-provider/{idpId} -H "Authorization: {api_key}" | jq '.identityProvider.applicationConfiguration | length'
- * </pre>
+ * Makes a PUT /api/identity-provider/{idpId} call, enabling the identity provider for
+ * a random selection of applications and tenants.
+ * Useful for finding race conditions (like DB deadlock).
  *
  * @author Brent Halsey
  */
-public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker {
+public class FusionAuthPutIdentityProviderWorker extends FusionAuthBaseWorker {
   private final AtomicInteger counter;
 
   private final UUID idpId;
 
   private final int maxAttempts;
 
-  public FusionAuthPatchIdentityProviderWorker(FusionAuthClient client, Configuration configuration, AtomicInteger counter) {
+  private final int numEnabledApplications;
+
+  private final int numEnabledTenants;
+
+  public FusionAuthPutIdentityProviderWorker(FusionAuthClient client, Configuration configuration, AtomicInteger counter) {
     super(client, configuration);
     this.counter = counter;
     if (configuration.hasProperty("idpId")) {
@@ -52,6 +63,19 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
     } else {
       this.idpId = null;
     }
+
+    if (configuration.hasProperty("numEnabledApplications")) {
+      this.numEnabledApplications = configuration.getInteger("numEnabledApplications");
+    } else {
+      this.numEnabledApplications = Integer.min(10, applicationCount);
+    }
+
+    if (configuration.hasProperty("numEnabledTenants")) {
+      this.numEnabledTenants = configuration.getInteger("numEnabledTenants");
+    } else {
+      this.numEnabledTenants = Integer.min(10, tenantCount);
+    }
+
     this.maxAttempts = configuration.getInteger("maxAttempts", 10);
   }
 
@@ -59,16 +83,39 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
   public boolean execute() {
     setApplicationIndex(counter.incrementAndGet());
 
-    Map<String, Object> patch = Map.of("identityProvider",
-                                       Map.of("tenantConfiguration",
-                                              Map.of(tenantId.toString(),
-                                                     Map.of("limitUserLinkCount",
-                                                            Map.of("maximumLinks", 42, "enabled", Boolean.TRUE)))));
-//    Map<String, Object> patch = Map.of("identityProvider",
-//                                       Map.of("applicationConfiguration",
-//                                              Map.of(applicationId.toString(),
-//                                                     Map.of("createRegistration", Boolean.TRUE, "enabled", Boolean.TRUE))));
-    ClientResponse<IdentityProviderResponse, Errors> result = retryablePatch(idpId, patch);
+    // build application configs for a random selection of applications
+    List<Integer> allApps = IntStream.rangeClosed(1, applicationCount).boxed().collect(Collectors.toList());
+    Collections.shuffle(allApps);
+    Map<UUID, OpenIdConnectApplicationConfiguration> appConfig = new HashMap<>();
+    for (int i = 0; i < numEnabledApplications; i++) {
+      appConfig.put(applicationUUID(allApps.get(i)), new OpenIdConnectApplicationConfiguration().with(a -> a.enabled = true));
+    }
+
+    // build tenant configs for a random selection of tenants
+    List<Integer> allTenants = IntStream.rangeClosed(1, tenantCount).boxed().collect(Collectors.toList());
+    Collections.shuffle(allTenants);
+    Map<UUID, IdentityProviderTenantConfiguration> tenantConfig = new HashMap<>();
+    for (int i = 0; i < numEnabledTenants; i++) {
+      tenantConfig.put(tenantUUID(allTenants.get(i)), new IdentityProviderTenantConfiguration()
+          .with(t -> t.limitUserLinkCount = new IdentityProviderLimitUserLinkingPolicy()
+              .with(p -> p.enabled = true)));
+    }
+
+    OpenIdConnectIdentityProvider idp = new OpenIdConnectIdentityProvider()
+        .with(i -> i.name = "load-test-oidc-idp")
+        .with(i -> i.enabled = true)
+        .with(i -> i.linkingStrategy = IdentityProviderLinkingStrategy.LinkByEmail)
+        .with(i -> i.applicationConfiguration = appConfig)
+        .with(i -> i.tenantConfiguration = tenantConfig)
+        .with(i -> i.oauth2 = new IdentityProviderOauth2Configuration()
+            .with(o -> o.client_id = "client_id")
+            .with(o -> o.client_secret = "client_secret")
+            .with(o -> o.authorization_endpoint = URI.create("https://idp.fusionauth.io/p/oauth2/authorize"))
+            .with(o -> o.token_endpoint = URI.create("https://idp.fusionauth.io/p/oauth2/token"))
+            .with(o -> o.userinfo_endpoint = URI.create("https://idp.fusionauth.io/p/oauth2/userinfo"))
+            .with(o -> o.emailClaim = "email"));
+
+    ClientResponse<IdentityProviderResponse, Errors> result = retryablePut(idpId, new IdentityProviderRequest(idp));
     if (result.wasSuccessful()) {
       return true;
     }
@@ -77,14 +124,14 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
     return false;
   }
 
-  private ClientResponse<IdentityProviderResponse, Errors> retryablePatch(UUID idpId, Map<String, Object> patch) {
-    return retryablePatch(idpId, patch, 1);
+  private ClientResponse<IdentityProviderResponse, Errors> retryablePut(UUID idpId, IdentityProviderRequest idpRequest) {
+    return retryablePut(idpId, idpRequest, 1);
   }
 
   // Do our own retry logic (until we add retry support in the java client)
-  private ClientResponse<IdentityProviderResponse, Errors> retryablePatch(UUID idpId, Map<String, Object> patch, int attempt) {
+  private ClientResponse<IdentityProviderResponse, Errors> retryablePut(UUID idpId, IdentityProviderRequest idpRequest, int attempt) {
 
-    ClientResponse<IdentityProviderResponse, Errors> result = client.patchIdentityProvider(idpId, patch);
+    ClientResponse<IdentityProviderResponse, Errors> result = client.updateIdentityProvider(idpId, idpRequest);
     if (result.wasSuccessful() || attempt == maxAttempts) {
       return result;
     } else if (result.status == 409) {
@@ -96,7 +143,7 @@ public class FusionAuthPatchIdentityProviderWorker extends FusionAuthBaseWorker 
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
-      return retryablePatch(idpId, patch, attempt + 1);
+      return retryablePut(idpId, idpRequest, attempt + 1);
     } else {
       printErrors(result);
       return result;

--- a/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
@@ -58,11 +58,10 @@ public class FusionAuthPutIdentityProviderWorker extends FusionAuthBaseWorker {
   public FusionAuthPutIdentityProviderWorker(FusionAuthClient client, Configuration configuration, AtomicInteger counter) {
     super(client, configuration);
     this.counter = counter;
-    if (configuration.hasProperty("idpId")) {
-      this.idpId = UUID.fromString(configuration.getString("idpId"));
-    } else {
-      this.idpId = null;
+    if (!configuration.hasProperty("idpId")) {
+      throw new IllegalArgumentException("Configuration property 'idpId' is required for FusionAuthPutIdentityProviderWorker.");
     }
+    this.idpId = UUID.fromString(configuration.getString("idpId"));
 
     if (configuration.hasProperty("numEnabledApplications")) {
       this.numEnabledApplications = configuration.getInteger("numEnabledApplications");
@@ -81,21 +80,22 @@ public class FusionAuthPutIdentityProviderWorker extends FusionAuthBaseWorker {
 
   @Override
   public boolean execute() {
-    setApplicationIndex(counter.incrementAndGet());
 
     // build application configs for a random selection of applications
     List<Integer> allApps = IntStream.rangeClosed(1, applicationCount).boxed().collect(Collectors.toList());
     Collections.shuffle(allApps);
+    int enabledApplications = Math.min(numEnabledApplications, applicationCount);
     Map<UUID, OpenIdConnectApplicationConfiguration> appConfig = new HashMap<>();
-    for (int i = 0; i < numEnabledApplications; i++) {
+    for (int i = 0; i < enabledApplications; i++) {
       appConfig.put(applicationUUID(allApps.get(i)), new OpenIdConnectApplicationConfiguration().with(a -> a.enabled = true));
     }
 
     // build tenant configs for a random selection of tenants
     List<Integer> allTenants = IntStream.rangeClosed(1, tenantCount).boxed().collect(Collectors.toList());
     Collections.shuffle(allTenants);
+    int enabledTenants = Math.min(numEnabledTenants, tenantCount);
     Map<UUID, IdentityProviderTenantConfiguration> tenantConfig = new HashMap<>();
-    for (int i = 0; i < numEnabledTenants; i++) {
+    for (int i = 0; i < enabledTenants; i++) {
       tenantConfig.put(tenantUUID(allTenants.get(i)), new IdentityProviderTenantConfiguration()
           .with(t -> t.limitUserLinkCount = new IdentityProviderLimitUserLinkingPolicy()
               .with(p -> p.enabled = true)));
@@ -137,14 +137,16 @@ public class FusionAuthPutIdentityProviderWorker extends FusionAuthBaseWorker {
       try {
         long backoff = (long) (500 * Math.pow(1.5, attempt));
         long jitter = (long) (Math.random() * 0.10 * backoff);
-        System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying\n", attempt, backoff, jitter);
+        if (debug) {
+          System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying%n", attempt, backoff, jitter);
+        }
         Thread.sleep(backoff + jitter);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
         throw new RuntimeException(e);
       }
       return retryablePut(idpId, idpRequest, attempt + 1);
     } else {
-      printErrors(result);
       return result;
     }
   }

--- a/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthPutIdentityProviderWorker.java
@@ -130,13 +130,12 @@ public class FusionAuthPutIdentityProviderWorker extends FusionAuthBaseWorker {
 
   // Do our own retry logic (until we add retry support in the java client)
   private ClientResponse<IdentityProviderResponse, Errors> retryablePut(UUID idpId, IdentityProviderRequest idpRequest, int attempt) {
-
     ClientResponse<IdentityProviderResponse, Errors> result = client.updateIdentityProvider(idpId, idpRequest);
     if (result.wasSuccessful() || attempt == maxAttempts) {
       return result;
     } else if (result.status == 409) {
       try {
-        long backoff = 500L * attempt;
+        long backoff = (long) (500 * Math.pow(1.5, attempt));
         long jitter = (long) (Math.random() * 0.10 * backoff);
         System.out.printf("Got 409 on attempt %d, sleeping for %d ms + %d ms and retrying\n", attempt, backoff, jitter);
         Thread.sleep(backoff + jitter);

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -66,6 +66,7 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
       case "update-password" -> new FusionAuthUpdatePasswordWorker(client, configuration);
       case "oauth2/authorize" -> new FusionAuthOAuth2AuthorizeWorker(client, configuration);
       case "patch-idp" -> new FusionAuthPatchIdentityProviderWorker(client, configuration, counter);
+      case "put-idp" -> new FusionAuthPutIdentityProviderWorker(client, configuration, counter);
       case "refresh" -> new FusionAuthRefreshWorker(client, configuration);
       case "register" -> new FusionAuthRegistrationWorker(client, configuration, counter);
       case "search" -> new FusionAuthSearchWorker(client, configuration);

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -65,6 +65,7 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
       case "login" -> new FusionAuthLoginWorker(client, configuration);
       case "update-password" -> new FusionAuthUpdatePasswordWorker(client, configuration);
       case "oauth2/authorize" -> new FusionAuthOAuth2AuthorizeWorker(client, configuration);
+      case "patch-idp" -> new FusionAuthPatchIdentityProviderWorker(client, configuration, counter);
       case "refresh" -> new FusionAuthRefreshWorker(client, configuration);
       case "register" -> new FusionAuthRegistrationWorker(client, configuration, counter);
       case "search" -> new FusionAuthSearchWorker(client, configuration);

--- a/src/main/resources/Create-Applications.json
+++ b/src/main/resources/Create-Applications.json
@@ -1,5 +1,5 @@
 {
-  "loopCount": 100,
+  "loopCount": 1000,
   "workerCount": 10,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
@@ -9,7 +9,7 @@
       "keyId": "b871576b-1729-4fb3-9d5a-768481663c88",
       "themeId": "75a068fd-e94b-451a-9aeb-3ddb9a3b5987",
       "url": "https://local.fusionauth.io",
-      "tenantCount": 10,
+      "tenantCount": 1000,
       "debug": true
     }
   },

--- a/src/main/resources/Patch-IdentityProvider.json
+++ b/src/main/resources/Patch-IdentityProvider.json
@@ -9,7 +9,6 @@
       "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
       "url": "https://local.fusionauth.io",
       "counter": 0,
-      "factor": 1,
       "idpId": "82339786-3dff-42a6-aac6-1f1ceecb6c46",
       "maxAttempts": 10,
       "debug": true,

--- a/src/main/resources/Patch-IdentityProvider.json
+++ b/src/main/resources/Patch-IdentityProvider.json
@@ -1,15 +1,20 @@
 {
-  "loopCount": 1000,
-  "workerCount": 1,
+  "loopCount": 100,
+  "workerCount": 10,
+  "rampWait": 9,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {
-      "directive": "create-tenant",
+      "directive": "patch-idp",
       "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
-      "keyId": "b871576b-1729-4fb3-9d5a-768481663c88",
-      "themeId": "75a068fd-e94b-451a-9aeb-3ddb9a3b5987",
       "url": "https://local.fusionauth.io",
-      "debug": true
+      "counter": 0,
+      "factor": 1,
+      "idpId": "82339786-3dff-42a6-aac6-1f1ceecb6c46",
+      "maxAttempts": 10,
+      "debug": true,
+      "applicationCount": 10000,
+      "tenantCount": 1000
     }
   },
   "listeners": [

--- a/src/main/resources/Patch-IdentityProvider.json
+++ b/src/main/resources/Patch-IdentityProvider.json
@@ -1,6 +1,6 @@
 {
   "loopCount": 100,
-  "workerCount": 10,
+  "workerCount": 100,
   "rampWait": 9,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",

--- a/src/main/resources/Put-IdentityProvider.json
+++ b/src/main/resources/Put-IdentityProvider.json
@@ -1,0 +1,31 @@
+{
+  "loopCount": 100,
+  "workerCount": 10,
+  "rampWait": 9,
+  "workerFactory": {
+    "className": "io.fusionauth.load.FusionAuthWorkerFactory",
+    "attributes": {
+      "directive": "patch-idp",
+      "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
+      "url": "https://local.fusionauth.io",
+      "counter": 0,
+      "factor": 1,
+      "idpId": "82339786-3dff-42a6-aac6-1f1ceecb6c46",
+      "maxAttempts": 10,
+      "debug": true,
+      "applicationCount": 10000,
+      "tenantCount": 1000
+    }
+  },
+  "listeners": [
+    {
+      "className": "io.fusionauth.load.listeners.ThroughputListener"
+    }
+  ],
+  "reporter": {
+    "className": "io.fusionauth.load.reporters.DefaultReporter",
+    "attributes": {
+      "interval": 5
+    }
+  }
+}

--- a/src/main/resources/Put-IdentityProvider.json
+++ b/src/main/resources/Put-IdentityProvider.json
@@ -1,17 +1,19 @@
 {
-  "loopCount": 100,
+  "loopCount": 10,
   "workerCount": 10,
   "rampWait": 9,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {
-      "directive": "patch-idp",
+      "directive": "put-idp",
       "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
       "url": "https://local.fusionauth.io",
       "counter": 0,
       "factor": 1,
-      "idpId": "82339786-3dff-42a6-aac6-1f1ceecb6c46",
+      "idpId": "eafb5ede-ca8e-4ad9-8968-df5671b45b06",
       "maxAttempts": 10,
+      "numEnabledApplications": 50,
+      "numEnabledTenants": 50,
       "debug": true,
       "applicationCount": 10000,
       "tenantCount": 1000

--- a/src/main/resources/Put-IdentityProvider.json
+++ b/src/main/resources/Put-IdentityProvider.json
@@ -9,7 +9,6 @@
       "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
       "url": "https://local.fusionauth.io",
       "counter": 0,
-      "factor": 1,
       "idpId": "eafb5ede-ca8e-4ad9-8968-df5671b45b06",
       "maxAttempts": 10,
       "numEnabledApplications": 50,

--- a/src/main/resources/Put-IdentityProvider.json
+++ b/src/main/resources/Put-IdentityProvider.json
@@ -1,6 +1,6 @@
 {
-  "loopCount": 10,
-  "workerCount": 10,
+  "loopCount": 100,
+  "workerCount": 100,
   "rampWait": 9,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",


### PR DESCRIPTION
### Issue:

- https://linear.app/fusionauth/issue/ENG-3965/reproduce-patch-issue

### Problem:

We need to reproduce the race condition in PATCH `/api/identity-provider` so we will know if we've fixed it. 

### Solution:

- Add workers that call PUT and PATCH on `/api/identity-provider`
- add retry logic for 409 responses

Tests can be run with
```
sb int
cd build/dist
./load-test.sh Create-Tenants.json
./load-test.sh Create-Applications.json

./load-test.sh Put-IdentityProvider.json
./load-test.sh Patch-IdentityProvider.json
```

### Linked PR:

- https://github.com/fusionauth-eng/fusionauth-app/pull/1334
