### PR TITLE
add FusionAuthStartPasswordlessWorker

### DIFF
--- a/src/main/java/io/fusionauth/load/FusionAuthCreateApplicationWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthCreateApplicationWorker.java
@@ -43,7 +43,9 @@ public class FusionAuthCreateApplicationWorker extends FusionAuthBaseWorker {
     Application application = new Application().with(a -> a.name = "application_" + applicationIndex)
                                                .with(a -> a.tenantId = tenantId)
                                                .with(a -> a.roles.add(new ApplicationRole("admin")))
-                                               .with(a -> a.roles.add(new ApplicationRole("user")));
+                                               .with(a -> a.roles.add(new ApplicationRole("user")))
+                                               .with(a -> a.passwordlessConfiguration.enabled = true)
+        ;
     ClientResponse<ApplicationResponse, Errors> result = tenantScopedClient.createApplication(applicationId, new ApplicationRequest(null, application));
     if (result.wasSuccessful()) {
       return true;

--- a/src/main/java/io/fusionauth/load/FusionAuthCreateTenantWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthCreateTenantWorker.java
@@ -64,7 +64,7 @@ public class FusionAuthCreateTenantWorker extends FusionAuthBaseWorker {
                                 .with(t -> t.externalIdentifierConfiguration.externalAuthenticationIdTimeToLiveInSeconds = 60)
                                 .with(t -> t.externalIdentifierConfiguration.oneTimePasswordTimeToLiveInSeconds = 60)
                                 .with(t -> t.externalIdentifierConfiguration.passwordlessLoginGenerator = new SecureGeneratorConfiguration(10, SecureGeneratorType.randomAlphaNumeric))
-                                .with(t -> t.externalIdentifierConfiguration.passwordlessLoginTimeToLiveInSeconds = 60)
+                                .with(t -> t.externalIdentifierConfiguration.passwordlessLoginTimeToLiveInSeconds = randomize(60))
                                 .with(t -> t.externalIdentifierConfiguration.registrationVerificationIdGenerator = new SecureGeneratorConfiguration(10, SecureGeneratorType.randomAlphaNumeric))
                                 .with(t -> t.externalIdentifierConfiguration.registrationVerificationIdTimeToLiveInSeconds = 60)
                                 .with(t -> t.externalIdentifierConfiguration.samlv2AuthNRequestIdTimeToLiveInSeconds = 60)
@@ -95,5 +95,9 @@ public class FusionAuthCreateTenantWorker extends FusionAuthBaseWorker {
 
     printErrors(result);
     return false;
+  }
+
+  int randomize(int x) {
+    return (int) ((Math.random() + 0.5) * (double) x);
   }
 }

--- a/src/main/java/io/fusionauth/load/FusionAuthStartPasswordlessWorker.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthStartPasswordlessWorker.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2012-2025, FusionAuth, All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+package io.fusionauth.load;
+
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import com.inversoft.error.Errors;
+import com.inversoft.rest.ClientResponse;
+import io.fusionauth.client.FusionAuthClient;
+import io.fusionauth.domain.api.passwordless.PasswordlessStartRequest;
+import io.fusionauth.domain.api.passwordless.PasswordlessStartResponse;
+
+/**
+ * Worker to test starting a passwordless login. This can be useful for generating External Ids for users.
+ */
+public class FusionAuthStartPasswordlessWorker extends FusionAuthBaseWorker {
+  private final UUID configuredApplicationId;
+
+  private final int loginLowerBound;
+
+  private final int loginUpperBound;
+
+  public FusionAuthStartPasswordlessWorker(FusionAuthClient client, Configuration configuration) {
+    super(client, configuration);
+    if (configuration.hasProperty("applicationId")) {
+      this.configuredApplicationId = UUID.fromString(configuration.getString("applicationId"));
+    } else {
+      this.configuredApplicationId = null;
+    }
+    this.loginLowerBound = configuration.getInteger("loginLowerBound", 0);
+    this.loginUpperBound = configuration.getInteger("loginUpperBound", 1_000_000);
+  }
+
+  @Override
+  public boolean execute() {
+    int index = new Random().nextInt((loginUpperBound - loginLowerBound) + 1) + loginLowerBound;
+    setUserIndex(index);
+    String email = "load_user_" + userIndex + "@fusionauth.io";
+
+    UUID registrationAppId = configuredApplicationId != null ? configuredApplicationId : applicationId;
+
+    ClientResponse<PasswordlessStartResponse, Errors> result = tenantScopedClient.startPasswordlessLogin(new PasswordlessStartRequest(registrationAppId, email, List.of("email"), null));
+    if (result.wasSuccessful()) {
+      return true;
+    }
+
+    printErrors(result);
+    return false;
+  }
+}

--- a/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
+++ b/src/main/java/io/fusionauth/load/FusionAuthWorkerFactory.java
@@ -71,6 +71,7 @@ public class FusionAuthWorkerFactory implements WorkerFactory {
       case "register" -> new FusionAuthRegistrationWorker(client, configuration, counter);
       case "search" -> new FusionAuthSearchWorker(client, configuration);
       case "search-data" -> new FusionAuthSearchDataWorker(client, configuration);
+      case "start-passwordless" -> new FusionAuthStartPasswordlessWorker(client, configuration);
       case "retrieve-email" -> new FusionAuthRetrieveEmailWorker(client, configuration);
       case "user-import" -> new FusionAuthUserImportWorker(client, configuration, counter);
       case "elasticsearch" -> new ElasticsearchWorker(configuration);

--- a/src/main/resources/Create-Applications.json
+++ b/src/main/resources/Create-Applications.json
@@ -9,7 +9,7 @@
       "keyId": "b871576b-1729-4fb3-9d5a-768481663c88",
       "themeId": "75a068fd-e94b-451a-9aeb-3ddb9a3b5987",
       "url": "https://local.fusionauth.io",
-      "tenantCount": 1000,
+      "tenantCount": 10000,
       "debug": true
     }
   },

--- a/src/main/resources/User-StartPasswordless-MultiTenant.json
+++ b/src/main/resources/User-StartPasswordless-MultiTenant.json
@@ -1,19 +1,17 @@
 {
   "loopCount": 1000,
   "workerCount": 100,
-  "rampWait": 9,
   "workerFactory": {
     "className": "io.fusionauth.load.FusionAuthWorkerFactory",
     "attributes": {
-      "directive": "register",
+      "directive": "start-passwordless",
       "apiKey": "bf69486b-4733-4470-a592-f1bfce7af580",
       "url": "https://local.fusionauth.io",
-      "counter": 0,
-      "encryptionScheme": "salted-pbkdf2-hmac-sha256",
-      "factor": 1,
+      "loginLowerBound": 1,
+      "loginUpperBound": 100000,
       "debug": true,
       "applicationCount": 10000,
-      "tenantCount": 10000
+      "tenantCount": 1000
     }
   },
   "listeners": [


### PR DESCRIPTION
### Issue:

- https://linear.app/fusionauth/issue/ENG-4312/generate-extids-in-load-test

### Problem:

We need a way to add a lot of external Ids to exercise reaping.

### Solution:

Add `FusionAuthStartPasswordlessWorker`

